### PR TITLE
Make Private DNS Resolvers optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ map(object({
       })))
       auto_registration_zone_enabled = optional(bool, false)
       auto_registration_zone_name    = optional(string, null)
-      subnet_address_prefix          = string
+      subnet_address_prefix          = optional(string)
       subnet_name                    = optional(string, "dns-resolver")
       private_dns_resolver = object({
         name                = string

--- a/locals.dns.tf
+++ b/locals.dns.tf
@@ -6,7 +6,7 @@ locals {
   private_dns_resolver_ip_addresses = { for key, value in var.hub_virtual_networks : key =>
     (value.private_dns_zones.private_dns_resolver.ip_address == null ?
       cidrhost(value.private_dns_zones.subnet_address_prefix, 4) :
-    value.private_dns_zones.private_dns_resolver.ip_address) if local.private_dns_zones_enabled[key]
+    value.private_dns_zones.private_dns_resolver.ip_address) if local.private_dns_zones_enabled[key] && try(value.private_dns_zones.private_dns_resolver, null) != null
   }
   private_dns_zones = { for key, value in var.hub_virtual_networks : key => merge({
     location = value.hub_virtual_network.location

--- a/locals.dns.tf
+++ b/locals.dns.tf
@@ -11,6 +11,9 @@ locals {
   private_dns_zones = { for key, value in var.hub_virtual_networks : key => merge({
     location = value.hub_virtual_network.location
   }, value.private_dns_zones) if local.private_dns_zones_enabled[key] }
+  private_dns_zones_resolvers = { for key, value in var.hub_virtual_networks : key => merge({
+    location = value.hub_virtual_network.location
+  }, value.private_dns_zones) if local.private_dns_zones_enabled[key] && try(value.private_dns_zones.private_dns_resolver, null) != null }
   private_dns_zones_auto_registration = { for key, value in var.hub_virtual_networks : key => merge({
     location         = value.hub_virtual_network.location
     vnet_resource_id = module.hub_and_spoke_vnet.virtual_networks[key].id

--- a/locals.subnets.tf
+++ b/locals.subnets.tf
@@ -33,7 +33,7 @@ locals {
           name = "Microsoft.Network/dnsResolvers"
         }
       }]
-    } } if local.private_dns_zones_enabled[key]
+    } } if local.private_dns_zones_enabled[key] && try(value.private_dns_zones.private_dns_resolver, null) != null
   }
   subnets = { for key, value in var.hub_virtual_networks : key => merge(lookup(local.private_dns_resolver_subnets, key, {}), lookup(local.bastion_subnets, key, {}), lookup(local.gateway_subnets, key, {})) }
 }

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ module "dns_resolver" {
   source  = "Azure/avm-res-network-dnsresolver/azurerm"
   version = "0.7.2"
 
-  for_each = local.private_dns_zones
+  for_each = local.private_dns_zones_resolvers
 
   location                    = each.value.location
   name                        = each.value.private_dns_resolver.name

--- a/variables.tf
+++ b/variables.tf
@@ -45,11 +45,11 @@ variable "hub_virtual_networks" {
       auto_registration_zone_name    = optional(string, null)
       subnet_address_prefix          = string
       subnet_name                    = optional(string, "dns-resolver")
-      private_dns_resolver = object({
+      private_dns_resolver = optional(object({
         name                = string
         resource_group_name = optional(string)
         ip_address          = optional(string)
-      })
+      }))
     }))
   }))
   default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -43,7 +43,7 @@ variable "hub_virtual_networks" {
       })))
       auto_registration_zone_enabled = optional(bool, false)
       auto_registration_zone_name    = optional(string, null)
-      subnet_address_prefix          = string
+      subnet_address_prefix          = optional(string)
       subnet_name                    = optional(string, "dns-resolver")
       private_dns_resolver = optional(object({
         name                = string


### PR DESCRIPTION
## Description

Allow for users to deploy Private DNS zones without deploying Private DNS Resolvers.

Closes #4 
Closes #3

I have tested this PR using my published fork module:

https://registry.terraform.io/modules/bbtechsys/avm-ptn-alz-connectivity-hub-and-spoke-vnet/azurerm/latest

```terraform
module "hub_and_spoke_vnet" {
  source  = "bbtechsys/avm-ptn-alz-connectivity-hub-and-spoke-vnet/azurerm"
  version = "0.1.2"
}
```

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
