### PR TITLE
feat: add output private_dns_zone_resource_ids

### DIFF
--- a/.github/policies/eventResponder.yml
+++ b/.github/policies/eventResponder.yml
@@ -17,6 +17,13 @@ configuration:
         then:
           - addLabel:
               label: "Needs: Triage :mag:"
+          - addReply:
+              reply: |
+                > [!IMPORTANT]
+                > **The "Needs: Triage :mag:" label must be removed once the triage process is complete!**
+
+                > [!TIP]
+                > For additional guidance on how to triage this issue/PR, see the [Terraform Issue Triage](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/terraform-issue-triage) documentation.
 
       - description: 'ITA09 - When #RR is used in an issue, add the "Needs: Author Feedback :ear:" label'
         if:
@@ -47,7 +54,7 @@ configuration:
               label: "Status: Won't Fix :broken_heart:"
           - closeIssue
 
-      - description: 'ITA11 - When a reply from anyone to an issue occurs, remove the "Needs: Author Feedback :ear:" label and label with "Needs: Attention :wave:"'
+      - description: 'ITA11 - When the author replies, remove the "Needs: Author Feedback :ear:" label and label with "Needs: Attention :wave:"'
         if:
           - or:
               - payloadType: Pull_Request_Review_Comment
@@ -57,9 +64,13 @@ configuration:
                 action: Closed
           - hasLabel:
               label: "Needs: Author Feedback :ear:"
+          - isActivitySender:
+              issueAuthor: true
         then:
           - removeLabel:
               label: "Needs: Author Feedback :ear:"
+          - removeLabel:
+              label: "Status: No Recent Activity :zzz:"
           - addLabel:
               label: "Needs: Attention :wave:"
 
@@ -89,12 +100,14 @@ configuration:
                   label: "Type: New Module Proposal :bulb:"
               - hasLabel:
                   label: "Type: Question/Feedback :raising_hand:"
+              - hasLabel:
+                  label: "Type: Security Bug :lock:"
           - isAssignedToSomeone
         then:
           - removeLabel:
               label: "Needs: Triage :mag:"
 
-      - description: 'ITA20 - If the type is feature request, add the "Type: Feature Request :heavy_plus_sign:" label on the issue'
+      - description: 'ITA20 - If the type is feature request, assign the "Type: Feature Request :heavy_plus_sign:" label on the issue'
         if:
           - payloadType: Issues
           - isAction:
@@ -111,7 +124,7 @@ configuration:
           - addLabel:
               label: "Type: Feature Request :heavy_plus_sign:"
 
-      - description: 'ITA21 - If the type is bug, add the "Type: Bug :bug:" label on the issue'
+      - description: 'ITA21 - If the type is bug, assign the "Type: Bug :bug:" label on the issue'
         if:
           - payloadType: Issues
           - isAction:
@@ -127,6 +140,23 @@ configuration:
         then:
           - addLabel:
               label: "Type: Bug :bug:"
+
+      - description: 'ITA22 - If the type is security bug, assign the "Type: Security Bug :lock:" label on the issue'
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+          - bodyContains:
+              pattern: |
+                ### Issue Type?
+
+                Security Bug
+          - not:
+              hasLabel:
+                label: "Type: Security Bug :lock:"
+        then:
+          - addLabel:
+              label: "Type: Security Bug :lock:"
 
       - description: 'ITA23 - Remove the "Status: In PR" label from an issue when it''s closed.'
         if:

--- a/.github/policies/scheduledSearches.yml
+++ b/.github/policies/scheduledSearches.yml
@@ -23,6 +23,8 @@ configuration:
           - isOpen
           - hasLabel:
               label: "Needs: Triage :mag:"
+          - isNotLabeledWith:
+              label: "Status: Response Overdue :triangular_flag_on_post:"
           - noActivitySince:
               days: 5
         actions:
@@ -52,6 +54,8 @@ configuration:
           - isOpen
           - hasLabel:
               label: "Needs: Triage :mag:"
+          - isNotLabeledWith:
+              label: "Status: Response Overdue :triangular_flag_on_post:"
           - noActivitySince:
               days: 3
         actions:
@@ -86,6 +90,8 @@ configuration:
           - isOpen
           - hasLabel:
               label: "Status: Response Overdue :triangular_flag_on_post:"
+          - isNotLabeledWith:
+              label: "Needs: Immediate Attention :bangbang:"
           - noActivitySince:
               days: 5
         actions:
@@ -102,7 +108,7 @@ configuration:
           - addLabel:
               label: "Needs: Immediate Attention :bangbang:"
 
-      - description: "ITA02TF.2 - Label issues as Needs Immediate Attention and leave comment if after an additional 3 business days there's still no update to the issue."
+      - description: "ITA02TF.2 - Label and comment issues as Needs Immediate Attention and leave comment if after an additional 3 business days there's still no update to the issue."
         frequencies:
           - weekday:
               day: Thursday
@@ -115,6 +121,8 @@ configuration:
           - isOpen
           - hasLabel:
               label: "Status: Response Overdue :triangular_flag_on_post:"
+          - isNotLabeledWith:
+              label: "Needs: Immediate Attention :bangbang:"
           - noActivitySince:
               days: 3
         actions:
@@ -123,7 +131,7 @@ configuration:
                 - Azure/avm-core-team-technical-terraform
               replyTemplate: |
                 > [!CAUTION]
-                > **This issue requires the AVM Core Team's (${mentionees}) immediate attention as  it hasn't been responded to within 6 business days. **
+                > **This issue requires the AVM Core Team's (${mentionees}) immediate attention as  it hasn't been responded to within 6 business days.**
 
                 > [!TIP]
                 > - To avoid this rule being (re)triggered, the "Needs: Triage :mag:" and "Status: Response Overdue :triangular_flag_on_post:" labels must be removed when the issue is first responded to!
@@ -175,12 +183,11 @@ configuration:
           - assignTo:
               user: Azure/terraform-avm
 
-      - description: "ITA04 - Label issues that have been marked as requiring author feedback but have not had any activity for 4 days."
+      - description: "ITA04 - Label issues and PRs that have been marked as requiring author feedback but have not had any activity for 4 days."
         frequencies:
           - hourly:
               hour: 3
         filters:
-          - isIssue
           - isOpen
           - hasLabel:
               label: "Needs: Author Feedback :ear:"
@@ -196,48 +203,4 @@ configuration:
           - addReply:
               reply: |
                 > [!IMPORTANT]
-                > @${issueAuthor}, this issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**.
-
-      - description: 'ITA05A - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
-        frequencies:
-          - hourly:
-              hour: 3
-        filters:
-          - isIssue
-          - isOpen
-          - hasLabel:
-              label: "Needs: Author Feedback :ear:"
-          - hasLabel:
-              label: "Status: No Recent Activity :zzz:"
-          - isNotLabeledWith:
-              label: "Needs: Module Owner :mega:"
-          - noActivitySince:
-              days: 3
-        actions:
-          - addReply:
-              reply: |
-                > [!WARNING]
-                > @${issueAuthor}, this issue will now be closed, as it has been marked as requiring author feedback but has not had any activity for **7 days**.
-          - closeIssue
-
-      - description: 'ITA05B - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
-        frequencies:
-          - hourly:
-              hour: 3
-        filters:
-          - isIssue
-          - isOpen
-          - hasLabel:
-              label: "Needs: Author Feedback :ear:"
-          - hasLabel:
-              label: "Status: No Recent Activity :zzz:"
-          - isNotLabeledWith:
-              label: "Status: Long Term :hourglass_flowing_sand:"
-          - noActivitySince:
-              days: 3
-        actions:
-          - addReply:
-              reply: |
-                > [!WARNING]
-                > @${issueAuthor}, this issue will now be closed, as it has been marked as requiring author feedback but has not had any activity for **7 days**.
-          - closeIssue
+                > @${issueAuthor}, this issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Description: Resource names of the firewalls.
 
 Description: Names of the virtual networks
 
+### <a name="output_private_dns_zone_resource_ids"></a> [private\_dns\_zone\_resource\_ids](#output\_private\_dns\_zone\_resource\_ids)
+
+Description: Resource IDs of the private DNS zones
+
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: Resource IDs of the virtual networks

--- a/avm
+++ b/avm
@@ -11,6 +11,8 @@ if [ ! "$(command -v "$CONTAINER_RUNTIME")" ]; then
     exit 1
 fi
 
+AVM_IMAGE=${AVM_IMAGE:-mcr.microsoft.com/azterraform}
+
 if [ -z "$1" ]; then
     echo "Error: Please provide a make target. See https://github.com/Azure/tfmod-scaffold/blob/main/avmmakefile for available targets."
     echo
@@ -26,7 +28,7 @@ fi
 # Check if we are running in a container
 # If we are then just run make directly
 if [ -z "$AVM_IN_CONTAINER" ]; then
-  $CONTAINER_RUNTIME run --pull always --user "$(id -u):$(id -g)" --rm -v "$(pwd)":/src -w /src -v $AZURE_CONFIG_DIR:/azureconfig -e AZURE_CONFIG_DIR=/azureconfig -e GITHUB_TOKEN -e GITHUB_REPOSITORY -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY_OWNER mcr.microsoft.com/azterraform make "$1"
+  $CONTAINER_RUNTIME run --pull always --user "$(id -u):$(id -g)" --rm -v "$(pwd)":/src -w /src -v $AZURE_CONFIG_DIR:/azureconfig -e AZURE_CONFIG_DIR=/azureconfig -e GITHUB_TOKEN -e GITHUB_REPOSITORY -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY_OWNER $AVM_IMAGE make "$1"
 else
   make "$1"
 fi

--- a/avm.bat
+++ b/avm.bat
@@ -11,13 +11,21 @@ IF ERRORLEVEL 1 (
     exit /b
 )
 
+IF DEFINED AVM_IMAGE (SET "AVM_IMAGE=%AVM_IMAGE%") ELSE (SET "AVM_IMAGE=mcr.microsoft.com/azterraform")
+
 REM Check if a make target is provided
 IF "%~1"=="" (
     echo Error: Please provide a make target. See https://github.com/Azure/tfmod-scaffold/blob/main/avmmakefile for available targets.
     exit /b
 )
 
+IF DEFINED NO_PULL (
+    SET "PULL_ARG="
+) ELSE (
+    SET "PULL_ARG=--pull always"
+)
+
 REM Run the make target with CONTAINER_RUNTIME
-%CONTAINER_RUNTIME% run --pull always --rm -v "%cd%":/src -w /src --user "1000:1000" -e GITHUB_TOKEN -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER mcr.microsoft.com/azterraform make %1
+%CONTAINER_RUNTIME% run %PULL_ARG% --rm -v "%cd%":/src -w /src --user "1000:1000" -e GITHUB_TOKEN -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER %AVM_IMAGE% make %1
 
 ENDLOCAL

--- a/examples/full-multi-region/README.md
+++ b/examples/full-multi-region/README.md
@@ -6,6 +6,7 @@ Uses the standard tfvars file for the multi-region with azure firewall scenario.
 ```hcl
 terraform {
   required_version = "~> 1.5"
+
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/full-multi-region/main.tf
+++ b/examples/full-multi-region/main.tf
@@ -1,5 +1,6 @@
 terraform {
   required_version = "~> 1.5"
+
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,6 +33,11 @@ output "name" {
   value       = { for key, value in module.hub_and_spoke_vnet.virtual_networks : key => value.name }
 }
 
+output "private_dns_zone_resource_ids" {
+  description = "Resource IDs of the private DNS zones"
+  value       = { for key, value in module.private_dns_zones.private_dns_zone_resource_ids : key => value.id }
+}
+
 output "resource_id" {
   description = "Resource IDs of the virtual networks"
   value       = { for key, value in module.hub_and_spoke_vnet.virtual_networks : key => value.id }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,6 @@
 terraform {
   required_version = ">= 1.9, < 2.0"
+
   required_providers {
     azapi = {
       source  = "azure/azapi"


### PR DESCRIPTION
## Description

This pull request adds an output for the _private_dns_zones_ module.
## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
