### PR TITLE
Update output to fix firewall policy retrieval

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "dns_server_ip_addresses" {
 
 output "firewall_policy_ids" {
   description = "Firewall policy IDs for each hub virtual network."
-  value       = { for key, value in var.hub_virtual_networks : key => try(value.hub_virtual_network.firewall_policy_id, "ToDo") }
+  value       = { for key, value in var.hub_virtual_networks : key => try(value.hub_virtual_network.firewall_policies, "ToDo") }
 }
 
 output "firewall_private_ip_addresses" {


### PR DESCRIPTION
## Description

Fix the missing implementation of Azure Firewall policy retrieval. 

Today you were trying to return firewall_policy_id while the output of module https://registry.terraform.io/modules/Azure/avm-ptn-hubnetworking is firewall_policies

Thus I propose to update the output to firewall_policies so we can retrieve firewall policies


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ x ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

I'm actually unsure how to perform the other checks above :/

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
