### PR TITLE
fix: error in private_dns_zone_resource_ids output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -35,7 +35,7 @@ output "name" {
 
 output "private_dns_zone_resource_ids" {
   description = "Resource IDs of the private DNS zones"
-  value       = { for key, value in module.private_dns_zones.private_dns_zone_resource_ids : key => value.id }
+  value       = { for key, value in module.private_dns_zones : key => value.private_dns_zone_resource_ids }
 }
 
 output "resource_id" {


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

There is an issue in the for of the _private_dns_zone_resource_ids_ output, which was introduced with version 0.9.1.
This PR resolves the output to not result in an error.

Rel #21

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
