### PR TITLE
Bug/vnetgateway short circuit evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,9 +222,9 @@ Version: 0.15.0
 
 ### <a name="module_virtual_network_gateway"></a> [virtual\_network\_gateway](#module\_virtual\_network\_gateway)
 
-Source: git::https://github.com/Azure/terraform-azurerm-avm-ptn-vnetgateway.git
+Source: Azure/avm-ptn-vnetgateway/azurerm
 
-Version: bug/express-route-circuit-peering-config
+Version: 0.10.2
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/README.md
+++ b/README.md
@@ -222,9 +222,9 @@ Version: 0.15.0
 
 ### <a name="module_virtual_network_gateway"></a> [virtual\_network\_gateway](#module\_virtual\_network\_gateway)
 
-Source: Azure/avm-ptn-vnetgateway/azurerm
+Source: git::https://github.com/Azure/terraform-azurerm-avm-ptn-vnetgateway.git
 
-Version: 0.9.0
+Version: bug/fix-short-circuit-syntax
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/README.md
+++ b/README.md
@@ -222,9 +222,9 @@ Version: 0.15.0
 
 ### <a name="module_virtual_network_gateway"></a> [virtual\_network\_gateway](#module\_virtual\_network\_gateway)
 
-Source: Azure/avm-ptn-vnetgateway/azurerm
+Source: git::https://github.com/Azure/terraform-azurerm-avm-ptn-vnetgateway.git
 
-Version: 0.10.1
+Version: bug/express-route-circuit-peering-config
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/README.md
+++ b/README.md
@@ -222,9 +222,9 @@ Version: 0.15.0
 
 ### <a name="module_virtual_network_gateway"></a> [virtual\_network\_gateway](#module\_virtual\_network\_gateway)
 
-Source: git::https://github.com/Azure/terraform-azurerm-avm-ptn-vnetgateway.git
+Source: Azure/avm-ptn-vnetgateway/azurerm
 
-Version: main
+Version: 0.10.1
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Version: 0.15.0
 
 Source: git::https://github.com/Azure/terraform-azurerm-avm-ptn-vnetgateway.git
 
-Version: bug/fix-short-circuit-syntax
+Version: main
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/main.tf
+++ b/main.tf
@@ -8,9 +8,8 @@ module "hub_and_spoke_vnet" {
 }
 
 module "virtual_network_gateway" {
-  source = "git::https://github.com/Azure/terraform-azurerm-avm-ptn-vnetgateway.git?ref=bug/express-route-circuit-peering-config"
-  # source  = "Azure/avm-ptn-vnetgateway/azurerm"
-  # version = "0.10.1"
+  source   = "Azure/avm-ptn-vnetgateway/azurerm"
+  version  = "0.10.2"
   for_each = local.virtual_network_gateways
 
   location                                  = each.value.virtual_network_gateway.location

--- a/main.tf
+++ b/main.tf
@@ -8,9 +8,8 @@ module "hub_and_spoke_vnet" {
 }
 
 module "virtual_network_gateway" {
-  source = "git::https://github.com/Azure/terraform-azurerm-avm-ptn-vnetgateway.git?ref=main"
-  # source   = "Azure/avm-ptn-vnetgateway/azurerm"
-  # version  = "0.9.0"
+  source   = "Azure/avm-ptn-vnetgateway/azurerm"
+  version  = "0.10.1"
   for_each = local.virtual_network_gateways
 
   location                                  = each.value.virtual_network_gateway.location

--- a/main.tf
+++ b/main.tf
@@ -8,8 +8,9 @@ module "hub_and_spoke_vnet" {
 }
 
 module "virtual_network_gateway" {
-  source   = "Azure/avm-ptn-vnetgateway/azurerm"
-  version  = "0.10.1"
+  source = "git::https://github.com/Azure/terraform-azurerm-avm-ptn-vnetgateway.git?ref=bug/express-route-circuit-peering-config"
+  # source  = "Azure/avm-ptn-vnetgateway/azurerm"
+  # version = "0.10.1"
   for_each = local.virtual_network_gateways
 
   location                                  = each.value.virtual_network_gateway.location

--- a/main.tf
+++ b/main.tf
@@ -8,8 +8,9 @@ module "hub_and_spoke_vnet" {
 }
 
 module "virtual_network_gateway" {
-  source   = "Azure/avm-ptn-vnetgateway/azurerm"
-  version  = "0.9.0"
+  source = "git::https://github.com/Azure/terraform-azurerm-avm-ptn-vnetgateway.git?ref=bug/fix-short-circuit-syntax"
+  # source   = "Azure/avm-ptn-vnetgateway/azurerm"
+  # version  = "0.9.0"
   for_each = local.virtual_network_gateways
 
   location                                  = each.value.virtual_network_gateway.location

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ module "hub_and_spoke_vnet" {
 }
 
 module "virtual_network_gateway" {
-  source = "git::https://github.com/Azure/terraform-azurerm-avm-ptn-vnetgateway.git?ref=bug/fix-short-circuit-syntax"
+  source = "git::https://github.com/Azure/terraform-azurerm-avm-ptn-vnetgateway.git?ref=main"
   # source   = "Azure/avm-ptn-vnetgateway/azurerm"
   # version  = "0.9.0"
   for_each = local.virtual_network_gateways


### PR DESCRIPTION
## Description

Upgrade the avm-ptn-vnetgateway module to the latest version to resolve internally reported bugs around the ability to deploy a virtual network gateway for express route and circuit peering. 

For mor details, check out the respective module PRs:

- PR for short circuit evaluations: https://github.com/Azure/terraform-azurerm-avm-ptn-vnetgateway/pull/132 
- PR for express route circuit peering: https://github.com/Azure/terraform-azurerm-avm-ptn-vnetgateway/pull/133


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
