### PR TITLE
fix: Error when trying to get attribute from null value

### DIFF
--- a/modules/hub-virtual-network-mesh/locals.firewall.tf
+++ b/modules/hub-virtual-network-mesh/locals.firewall.tf
@@ -77,7 +77,7 @@ locals {
       sku_tier            = vnet.firewall.management_ip_configuration.public_ip_config.sku_tier
       tags                = vnet.firewall.tags
       zones               = vnet.firewall.management_ip_configuration.public_ip_config.zones
-    } if vnet.firewall != null && vnet.firewall.management_ip_enabled
+    } if vnet.firewall != null && try(vnet.firewall.management_ip_enabled, false)
   }
   fw_policies = {
     for vnet_name, vnet in var.hub_virtual_networks : vnet_name => {
@@ -98,6 +98,6 @@ locals {
       threat_intelligence_mode          = vnet.firewall.firewall_policy.threat_intelligence_mode
       tls_certificate                   = vnet.firewall.firewall_policy.tls_certificate
       tags                              = vnet.firewall.tags
-    } if vnet.firewall != null && vnet.firewall.firewall_policy != null && vnet.firewall.firewall_policy_id == null
+    } if vnet.firewall != null && try(vnet.firewall.firewall_policy != null, false) && try(vnet.firewall.firewall_policy_id == null, false)
   }
 }


### PR DESCRIPTION
If vnet.firewall is null, the other conditions error out because null value does not have any attributes. Added try statements around the conditions to handle this error.

## Description

After upgrading to 0.14.7, I received an error on some conditions because vnet.firewall was null.
I added some try statements to overcome this error.
When reverting to 0.14.6, I do not have this error.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [X] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
