### PR TITLE
fix: minimum terraform cli version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This module is leveraged by the [Azure Landing Zones IaC Accelerator](https://ak
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.12)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
 
@@ -407,6 +407,7 @@ The following top level attributes are supported:
         - `customer_asn` - (Optional) The customer ASN.
         - `routing_registry_name` - (Optional) The routing registry name.
   - `express_route_remote_vnet_traffic_enabled` - (Optional) Should remote VNet traffic be enabled? Default `false`.
+  - `express_route_virtual_wan_traffic_enabled` - (Optional) Should virtual WAN traffic be enabled? Default `false`.
   - `hosted_on_behalf_of_public_ip_enabled` - (Optional) Should hosted on behalf of public IP be enabled? Default `false`.
   - `ip_configurations` - (Optional) A map of IP configurations. Each configuration is an object with:
     - `name` - (Optional) The name of the IP configuration.
@@ -475,6 +476,7 @@ The following top level attributes are supported:
         - `local_address_prefixes` - A list of local address prefixes (required).
         - `remote_address_prefixes` - A list of remote address prefixes (required).
   - `tags` - (Optional) A map of tags to apply to the ExpressRoute gateway.
+  - `vpn_type` - (Optional) The VPN type. Possible values are `RouteBased`, `PolicyBased`.
 
 ### VPN Gateway
 
@@ -885,6 +887,7 @@ map(object({
           }), null)
         })))
         express_route_remote_vnet_traffic_enabled = optional(bool, false)
+        express_route_virtual_wan_traffic_enabled = optional(bool, false)
         hosted_on_behalf_of_public_ip_enabled     = optional(bool, true)
         ip_configurations = optional(map(object({
           name                          = optional(string, null)
@@ -962,7 +965,8 @@ map(object({
             ), null)
           }), null)
         })))
-        tags = optional(map(string))
+        tags     = optional(map(string))
+        vpn_type = optional(string, "RouteBased")
       }), {})
 
       vpn = optional(object({

--- a/examples/basic-options-and-single-region/README.md
+++ b/examples/basic-options-and-single-region/README.md
@@ -6,7 +6,7 @@ Single region with some options turned off and custom naming conventions.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     azurerm = {
@@ -93,7 +93,7 @@ module "test" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.12)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.21)
 

--- a/examples/basic-options-and-single-region/main.tf
+++ b/examples/basic-options-and-single-region/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     azurerm = {

--- a/examples/firewall-basic-sku/README.md
+++ b/examples/firewall-basic-sku/README.md
@@ -6,7 +6,7 @@ Shows minimal config for Azure Firewall with Basic SKU in a hub virtual network.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     azurerm = {
@@ -107,7 +107,7 @@ module "test" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.12)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.21)
 

--- a/examples/firewall-basic-sku/main.tf
+++ b/examples/firewall-basic-sku/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     azurerm = {

--- a/examples/firewall-policy-alternative-region/README.md
+++ b/examples/firewall-policy-alternative-region/README.md
@@ -6,7 +6,7 @@ Demonstrates how to create an Azure Firewall Policy in a different region to the
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     azurerm = {
@@ -107,7 +107,7 @@ module "test" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.12)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.21)
 

--- a/examples/firewall-policy-alternative-region/main.tf
+++ b/examples/firewall-policy-alternative-region/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     azurerm = {

--- a/examples/full-multi-region/README.md
+++ b/examples/full-multi-region/README.md
@@ -6,7 +6,7 @@ Uses the standard tfvars file for the multi-region with azure firewall scenario.
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     azurerm = {
@@ -76,7 +76,7 @@ module "test" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.12)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.21)
 

--- a/examples/full-multi-region/main.tf
+++ b/examples/full-multi-region/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     azurerm = {

--- a/examples/minimal-config/README.md
+++ b/examples/minimal-config/README.md
@@ -6,7 +6,7 @@ Shows the minimum config required to deploy a full multi-region platform landing
 
 ```hcl
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     azurerm = {
@@ -87,7 +87,7 @@ module "test" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.12)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.21)
 

--- a/examples/minimal-config/main.tf
+++ b/examples/minimal-config/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     azurerm = {

--- a/modules/hub-virtual-network-mesh/README.md
+++ b/modules/hub-virtual-network-mesh/README.md
@@ -52,7 +52,7 @@ module "hub" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.12)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
 

--- a/modules/hub-virtual-network-mesh/terraform.tf
+++ b/modules/hub-virtual-network-mesh/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = "~> 1.12"
 
   required_providers {
     azapi = {

--- a/modules/virtual-network-gateway/README.md
+++ b/modules/virtual-network-gateway/README.md
@@ -53,7 +53,7 @@ module "vgw" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.12)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
 

--- a/modules/virtual-network-gateway/terraform.tf
+++ b/modules/virtual-network-gateway/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = "~> 1.12"
 
   required_providers {
     azapi = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.9, < 2.0"
+  required_version = "~> 1.12"
 
   required_providers {
     azapi = {


### PR DESCRIPTION
## Description

The latest module code is dependent on short circuit evaluation introduced in v1.12 for Terraform CLI.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
