### PR TITLE
chore: update private DNS zones module version to 0.23.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ Default:
 
 ### <a name="input_enable_telemetry"></a> [enable\_telemetry](#input\_enable\_telemetry)
 
-Description: This variable controls whether or not telemetry is enabled for the module.  
-For more information see <https://aka.ms/avm/telemetryinfo>.  
+Description: This variable controls whether or not telemetry is enabled for the module.
+For more information see <https://aka.ms/avm/telemetryinfo>.
 If it is set to false, then no telemetry will be collected.
 
 Type: `bool`
@@ -1365,8 +1365,8 @@ Default: `{}`
 
 ### <a name="input_tags"></a> [tags](#input\_tags)
 
-Description: (Optional) A map of tags to assign to the resources created by this module.  
-These tags will be applied to all resources that support tagging, unless overridden by resource-specific tag configurations.  
+Description: (Optional) A map of tags to assign to the resources created by this module.
+These tags will be applied to all resources that support tagging, unless overridden by resource-specific tag configurations.
 Tags are key-value pairs that help you categorize resources and view consolidated billing by applying the same tag to multiple resources and resource groups.
 
 Example:
@@ -1531,7 +1531,7 @@ Version: 0.4.3
 
 Source: Azure/avm-ptn-network-private-link-private-dns-zones/azurerm
 
-Version: 0.22.2
+Version: 0.23.1
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 

--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ module "dns_resolver" {
 
 module "private_dns_zones" {
   source   = "Azure/avm-ptn-network-private-link-private-dns-zones/azurerm"
-  version  = "0.22.2"
+  version  = "0.23.1"
   for_each = local.private_dns_zones
 
   location                                                   = each.value.location


### PR DESCRIPTION
This pull request updates the version of the `Azure/avm-ptn-network-private-link-private-dns-zones/azurerm` module from `0.22.2` to `0.23.1` to ensure the codebase uses the latest features and fixes from that module.

Dependency version update:

* Updated the `version` attribute for the `private_dns_zones` module in `main.tf` to `0.23.1`.
* Updated the documented version in the `README.md` to `0.23.1`.