### PR TITLE
feat: Add ip_tags support for Azure Firewall public IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ The following top level attributes are supported:
       - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
       - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. For IP plan use Enabled. Possible values are Disabled, Enabled, VirtualNetworkInherited
       - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID. For IP plan do not create ddos plan, nor send in id here
+      - `ip_tags` - (Optional) A map of IP tags to assign to the public IP. Use this to declare ARM-applied tags (e.g. `FirstPartyUsage`) so Terraform does not detect drift. Defaults to `{}`.
   - `ip_configurations` - (Optional) A map of the default IP configuration for the Azure Firewall. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the default IP configuration. If not specified will use `default`.
     - `is_default` - (Optional) Indicates this is the default IP configuration, which will be linked to the Firewall subnet. If not specified will be `false`. At least one and only one IP configuration must have this set to `true`.
@@ -301,6 +302,7 @@ The following top level attributes are supported:
       - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
       - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. For IP plan use Enabled. Possible values are Disabled, Enabled, VirtualNetworkInherited
       - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID. For IP plan do not create ddos plan, nor send in id here
+      - `ip_tags` - (Optional) A map of IP tags to assign to the public IP. Use this to declare ARM-applied tags (e.g. `FirstPartyUsage`) so Terraform does not detect drift. Defaults to `{}`.
   - `management_ip_configuration` - (Optional) An object with the following fields. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the management IP configuration. If not specified will use `defaultMgmt`.
     - `public_ip_config` - (Optional) An object with the following fields:
@@ -313,6 +315,7 @@ The following top level attributes are supported:
       - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
       - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. For IP plan use Enabled. Possible values are Disabled, Enabled, VirtualNetworkInherited
       - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID. For IP plan do not create ddos plan, nor send in id here
+      - `ip_tags` - (Optional) A map of IP tags to assign to the public IP. Use this to declare ARM-applied tags (e.g. `FirstPartyUsage`) so Terraform does not detect drift. Defaults to `{}`.
 
 ## Azure Firewall Policy
 
@@ -985,6 +988,7 @@ map(object({
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }), {})
       }), {})
 
@@ -1001,6 +1005,7 @@ map(object({
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }), {})
       })), {})
 
@@ -1016,6 +1021,7 @@ map(object({
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }), {})
       }), {})
     }), {})

--- a/modules/hub-virtual-network-mesh/README.md
+++ b/modules/hub-virtual-network-mesh/README.md
@@ -187,6 +187,7 @@ Description: A map of the hub virtual networks to create. The map key is an arbi
       - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
       - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. For IP plan use Enabled
       - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID. For IP plan do not create ddos plan, nor send in id here
+      - `ip_tags` - (Optional) A map of IP tags to assign to the public IP. Use this to declare ARM-applied tags (e.g. `FirstPartyUsage`) so Terraform does not detect drift. Defaults to `{}`.
   - `ip_configurations` - (Optional) A map of the default IP configuration for the Azure Firewall. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the default IP configuration. If not specified will use `default`.
     - `is_default` - (Optional) Indicates this is the default IP configuration, which will be linked to the Firewall subnet. If not specified will be `false`. At least one and only one IP configuration must have this set to `true`.
@@ -198,6 +199,7 @@ Description: A map of the hub virtual networks to create. The map key is an arbi
       - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
       - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. For IP plan use Enabled
       - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID. For IP plan do not create ddos plan, nor send in id here
+      - `ip_tags` - (Optional) A map of IP tags to assign to the public IP. Use this to declare ARM-applied tags (e.g. `FirstPartyUsage`) so Terraform does not detect drift. Defaults to `{}`.
   - `management_ip_configuration` - (Optional) An object with the following fields. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the management IP configuration. If not specified will use `defaultMgmt`.
     - `public_ip_config` - (Optional) An object with the following fields:
@@ -208,6 +210,7 @@ Description: A map of the hub virtual networks to create. The map key is an arbi
       - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
       - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. For IP plan use Enabled
       - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID. For IP plan do not create ddos plan, nor send in id here
+      - `ip_tags` - (Optional) A map of IP tags to assign to the public IP. Use this to declare ARM-applied tags (e.g. `FirstPartyUsage`) so Terraform does not detect drift. Defaults to `{}`.
   - `firewall_policy` - (Optional) An object with the following fields. Cannot be used with `firewall_policy_id`. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the firewall policy. If not specified will use `afw-policy-{vnetname}`.
     - `sku` - (Optional) The SKU to use for the firewall policy. Possible values include `Standard`, `Premium`.
@@ -372,6 +375,7 @@ map(object({
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }))
       }))
       ip_configurations = optional(map(object({
@@ -387,6 +391,7 @@ map(object({
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }))
       })), {})
       management_ip_configuration = optional(object({
@@ -401,6 +406,7 @@ map(object({
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }))
       }))
       firewall_policy = optional(object({

--- a/modules/hub-virtual-network-mesh/locals.firewall.tf
+++ b/modules/hub-virtual-network-mesh/locals.firewall.tf
@@ -70,6 +70,7 @@ locals {
         domain_name_label       = ip_config_value.public_ip_config.domain_name_label
         ddos_protection_mode    = ip_config_value.public_ip_config.ddos_protection_mode
         ddos_protection_plan_id = ip_config_value.public_ip_config.ddos_protection_plan_id
+        ip_tags                 = ip_config_value.public_ip_config.ip_tags
       }
     ]
   ]) : public_ip.composite_key => public_ip }
@@ -86,6 +87,7 @@ locals {
       domain_name_label       = vnet.firewall.management_ip_configuration.public_ip_config.domain_name_label
       ddos_protection_mode    = vnet.firewall.management_ip_configuration.public_ip_config.ddos_protection_mode
       ddos_protection_plan_id = vnet.firewall.management_ip_configuration.public_ip_config.ddos_protection_plan_id
+      ip_tags                 = vnet.firewall.management_ip_configuration.public_ip_config.ip_tags
     } if vnet.firewall != null && vnet.firewall.management_ip_enabled
   }
   fw_policies = {

--- a/modules/hub-virtual-network-mesh/main.firewall.tf
+++ b/modules/hub-virtual-network-mesh/main.firewall.tf
@@ -35,6 +35,7 @@ module "fw_default_ips" {
   ddos_protection_plan_id = each.value.ddos_protection_plan_id
   domain_name_label       = each.value.domain_name_label
   enable_telemetry        = var.enable_telemetry
+  ip_tags                 = each.value.ip_tags
   ip_version              = each.value.ip_version
   public_ip_prefix_id     = each.value.public_ip_prefix_id
   sku                     = "Standard"
@@ -56,6 +57,7 @@ module "fw_management_ips" {
   ddos_protection_plan_id = each.value.ddos_protection_plan_id
   domain_name_label       = each.value.domain_name_label
   enable_telemetry        = var.enable_telemetry
+  ip_tags                 = each.value.ip_tags
   ip_version              = each.value.ip_version
   public_ip_prefix_id     = each.value.public_ip_prefix_id
   sku                     = "Standard"

--- a/modules/hub-virtual-network-mesh/variables.tf
+++ b/modules/hub-virtual-network-mesh/variables.tf
@@ -157,6 +157,7 @@ variable "hub_virtual_networks" {
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }))
       }))
       ip_configurations = optional(map(object({
@@ -172,6 +173,7 @@ variable "hub_virtual_networks" {
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }))
       })), {})
       management_ip_configuration = optional(object({
@@ -186,6 +188,7 @@ variable "hub_virtual_networks" {
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }))
       }))
       firewall_policy = optional(object({
@@ -348,6 +351,7 @@ A map of the hub virtual networks to create. The map key is an arbitrary value t
       - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
       - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. For IP plan use Enabled
       - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID. For IP plan do not create ddos plan, nor send in id here
+      - `ip_tags` - (Optional) A map of IP tags to assign to the public IP. Use this to declare ARM-applied tags (e.g. `FirstPartyUsage`) so Terraform does not detect drift. Defaults to `{}`.
   - `ip_configurations` - (Optional) A map of the default IP configuration for the Azure Firewall. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the default IP configuration. If not specified will use `default`.
     - `is_default` - (Optional) Indicates this is the default IP configuration, which will be linked to the Firewall subnet. If not specified will be `false`. At least one and only one IP configuration must have this set to `true`.
@@ -359,6 +363,7 @@ A map of the hub virtual networks to create. The map key is an arbitrary value t
       - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
       - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. For IP plan use Enabled
       - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID. For IP plan do not create ddos plan, nor send in id here
+      - `ip_tags` - (Optional) A map of IP tags to assign to the public IP. Use this to declare ARM-applied tags (e.g. `FirstPartyUsage`) so Terraform does not detect drift. Defaults to `{}`.
   - `management_ip_configuration` - (Optional) An object with the following fields. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the management IP configuration. If not specified will use `defaultMgmt`.
     - `public_ip_config` - (Optional) An object with the following fields:
@@ -369,6 +374,7 @@ A map of the hub virtual networks to create. The map key is an arbitrary value t
       - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
       - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. For IP plan use Enabled
       - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID. For IP plan do not create ddos plan, nor send in id here
+      - `ip_tags` - (Optional) A map of IP tags to assign to the public IP. Use this to declare ARM-applied tags (e.g. `FirstPartyUsage`) so Terraform does not detect drift. Defaults to `{}`.
   - `firewall_policy` - (Optional) An object with the following fields. Cannot be used with `firewall_policy_id`. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the firewall policy. If not specified will use `afw-policy-{vnetname}`.
     - `sku` - (Optional) The SKU to use for the firewall policy. Possible values include `Standard`, `Premium`.

--- a/variables.tf
+++ b/variables.tf
@@ -276,6 +276,7 @@ variable "hub_virtual_networks" {
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }), {})
       }), {})
 
@@ -292,6 +293,7 @@ variable "hub_virtual_networks" {
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }), {})
       })), {})
 
@@ -307,6 +309,7 @@ variable "hub_virtual_networks" {
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }), {})
       }), {})
     }), {})
@@ -975,6 +978,7 @@ The following top level attributes are supported:
       - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
       - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. For IP plan use Enabled. Possible values are Disabled, Enabled, VirtualNetworkInherited
       - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID. For IP plan do not create ddos plan, nor send in id here
+      - `ip_tags` - (Optional) A map of IP tags to assign to the public IP. Use this to declare ARM-applied tags (e.g. `FirstPartyUsage`) so Terraform does not detect drift. Defaults to `{}`.
   - `ip_configurations` - (Optional) A map of the default IP configuration for the Azure Firewall. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the default IP configuration. If not specified will use `default`.
     - `is_default` - (Optional) Indicates this is the default IP configuration, which will be linked to the Firewall subnet. If not specified will be `false`. At least one and only one IP configuration must have this set to `true`.
@@ -988,6 +992,7 @@ The following top level attributes are supported:
       - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
       - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. For IP plan use Enabled. Possible values are Disabled, Enabled, VirtualNetworkInherited
       - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID. For IP plan do not create ddos plan, nor send in id here
+      - `ip_tags` - (Optional) A map of IP tags to assign to the public IP. Use this to declare ARM-applied tags (e.g. `FirstPartyUsage`) so Terraform does not detect drift. Defaults to `{}`.
   - `management_ip_configuration` - (Optional) An object with the following fields. If not specified the defaults below will be used:
     - `name` - (Optional) The name of the management IP configuration. If not specified will use `defaultMgmt`.
     - `public_ip_config` - (Optional) An object with the following fields:
@@ -1000,6 +1005,7 @@ The following top level attributes are supported:
       - `public_ip_prefix_id` - (Optional) The ID of the public IP prefix.
       - `ddos_protection_mode` - (Optional) The DDoS protection mode. Default `VirtualNetworkInherited`. For IP plan use Enabled. Possible values are Disabled, Enabled, VirtualNetworkInherited
       - `ddos_protection_plan_id` - (Optional) The DDoS protection plan ID. For IP plan do not create ddos plan, nor send in id here
+      - `ip_tags` - (Optional) A map of IP tags to assign to the public IP. Use this to declare ARM-applied tags (e.g. `FirstPartyUsage`) so Terraform does not detect drift. Defaults to `{}`.
 
 ## Azure Firewall Policy
 


### PR DESCRIPTION
## Description

This PR adds ip_tags passthrough support to Azure Firewall public IP configurations (both default and management IPs).

### Problem
When Azure ARM automatically applies tags to firewall public IPs (e.g., FirstPartyUsage: /Unprivileged), Terraform detects configuration drift because the module doesn't expose a way to declare these tags. This creates an infinite drift loop where Terraform wants to remove the ARM-applied tags, but Azure reapplies them on every refresh.

### Solution
Add ip_tags field to public_ip_config objects in the firewall configuration, following the exact same pattern used in:
- PR #130 (DDoS protection mode/plan passthrough)
- PR #119 (domain_name_label passthrough)

The underlying PIP sub-module (Azure/avm-res-network-publicipaddress/azurerm@0.2.0) already accepts ip_tags as input; this PR simply wires it through the pattern module layers.

### Evidence
We encountered this issue in production and implemented a local fork as a workaround: https://github.com/martinopedal/alz-avm-tf-demo/commit/273e665

### Changes
- modules/hub-virtual-network-mesh/variables.tf: Add ip_tags to all three public_ip_config object types
- modules/hub-virtual-network-mesh/locals.firewall.tf: Pass ip_tags through to PIP locals
- modules/hub-virtual-network-mesh/main.firewall.tf: Wire ip_tags to both w_default_ips and w_management_ips module calls
- READMEs: Updated via terraform-docs

## Type of Change

- [x] Azure Verified Module updates:
  - [x] Feature update backwards compatible feature updates.

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all pre-commit checks (terraform-docs completed successfully)