### PR TITLE
fix: forward ip_tags to firewall public IPs to avoid forced replacement (PublicIPAddressCannotBeDeleted)

### DIFF
--- a/modules/hub-virtual-network-mesh/locals.firewall.tf
+++ b/modules/hub-virtual-network-mesh/locals.firewall.tf
@@ -70,6 +70,7 @@ locals {
         domain_name_label       = ip_config_value.public_ip_config.domain_name_label
         ddos_protection_mode    = ip_config_value.public_ip_config.ddos_protection_mode
         ddos_protection_plan_id = ip_config_value.public_ip_config.ddos_protection_plan_id
+        ip_tags                 = ip_config_value.public_ip_config.ip_tags
       }
     ]
   ]) : public_ip.composite_key => public_ip }
@@ -86,6 +87,7 @@ locals {
       domain_name_label       = vnet.firewall.management_ip_configuration.public_ip_config.domain_name_label
       ddos_protection_mode    = vnet.firewall.management_ip_configuration.public_ip_config.ddos_protection_mode
       ddos_protection_plan_id = vnet.firewall.management_ip_configuration.public_ip_config.ddos_protection_plan_id
+      ip_tags                 = vnet.firewall.management_ip_configuration.public_ip_config.ip_tags
     } if vnet.firewall != null && vnet.firewall.management_ip_enabled
   }
   fw_policies = {

--- a/modules/hub-virtual-network-mesh/main.firewall.tf
+++ b/modules/hub-virtual-network-mesh/main.firewall.tf
@@ -41,6 +41,7 @@ module "fw_default_ips" {
   sku_tier                = each.value.sku_tier
   tags                    = each.value.tags == null ? var.tags : each.value.tags
   zones                   = each.value.zones
+  ip_tags                 = each.value.ip_tags
 }
 
 module "fw_management_ips" {
@@ -62,6 +63,7 @@ module "fw_management_ips" {
   sku_tier                = each.value.sku_tier
   tags                    = each.value.tags == null ? var.tags : each.value.tags
   zones                   = each.value.zones
+  ip_tags                 = each.value.ip_tags
 }
 
 module "fw_policies" {

--- a/modules/hub-virtual-network-mesh/variables.tf
+++ b/modules/hub-virtual-network-mesh/variables.tf
@@ -157,6 +157,7 @@ variable "hub_virtual_networks" {
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }))
       }))
       ip_configurations = optional(map(object({
@@ -172,6 +173,7 @@ variable "hub_virtual_networks" {
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }))
       })), {})
       management_ip_configuration = optional(object({
@@ -186,6 +188,7 @@ variable "hub_virtual_networks" {
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }))
       }))
       firewall_policy = optional(object({

--- a/variables.tf
+++ b/variables.tf
@@ -276,6 +276,7 @@ variable "hub_virtual_networks" {
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }), {})
       }), {})
 
@@ -292,6 +293,7 @@ variable "hub_virtual_networks" {
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }), {})
       })), {})
 
@@ -307,6 +309,7 @@ variable "hub_virtual_networks" {
           domain_name_label       = optional(string)
           ddos_protection_mode    = optional(string, "VirtualNetworkInherited")
           ddos_protection_plan_id = optional(string, null)
+          ip_tags                 = optional(map(string), {})
         }), {})
       }), {})
     }), {})


### PR DESCRIPTION
## Description

The firewall `public_ip_config` object does not expose an `ip_tags` attribute, so the module always sends an empty IP-tag set to the underlying `Azure/avm-res-network-publicipaddress` module for the firewall public IPs.

In subscriptions where IP tags are applied out-of-band, this is a problem. For example, Azure Policy and MCAPS-style sponsored subscriptions inject an immutable tag such as `FirstPartyUsage = "/Unprivileged"` onto every public IP at create time. Because `ip_tags` are immutable on an existing public IP, the next `terraform apply` sees the externally-applied tag versus the module's empty `ip_tags` and plans a **forced replacement** of the firewall public IP. That replacement then fails with:

```
PublicIPAddressCannotBeDeleted: Public IP address ... can not be deleted since it is still allocated to resource ... azureFirewallIpConfiguration.
```

This leaves the firewall stack un-appliable (perpetual destroy/recreate that can never succeed while the PIP is attached to the firewall).

The gateway `public_ip_config` blocks already support `ip_tags`; this change brings the firewall public IP configurations to parity so users can declare the same IP tags that the platform applies and avoid the forced replacement.

### What changed

Added an optional `ip_tags = optional(map(string), {})` to the firewall `public_ip_config` schema and forwarded it through to the public IP module calls:

- `variables.tf` — added `ip_tags` to the `default_ip_configuration`, `ip_configurations`, and `management_ip_configuration` `public_ip_config` objects.
- `modules/hub-virtual-network-mesh/variables.tf` — same three additions.
- `modules/hub-virtual-network-mesh/locals.firewall.tf` — carried `ip_tags` through `fw_default_ip_configuration_pip` and `fw_management_ip_configuration_pip`.
- `modules/hub-virtual-network-mesh/main.firewall.tf` — forwarded `ip_tags` to the `fw_default_ips` and `fw_management_ips` module calls.

The default of `{}` preserves existing behaviour for everyone not setting it (backwards compatible).

### Verification

- `terraform fmt -recursive` clean.
- `terraform validate` succeeds.
- Verified against a real plan in an MCAPS subscription that auto-injects `FirstPartyUsage = "/Unprivileged"`: before the change the firewall PIPs showed `ip_tags # forces replacement`; after setting `ip_tags` to match, the firewall public IPs are no longer replaced.

Relates to Azure/Azure-Landing-Zones#4196

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
