### PR TITLE
fix: convert lifecycle shell hooks to PowerShell

### DIFF
--- a/examples/full-multi-region/pre.ps1
+++ b/examples/full-multi-region/pre.ps1
@@ -1,0 +1,14 @@
+#!/usr/bin/env pwsh
+# Adds randomness to the resource group names in test.auto.tfvars.
+# Source of test.auto.tfvars: https://raw.githubusercontent.com/Azure/alz-terraform-accelerator/refs/heads/main/templates/platform_landing_zone/examples/full-multi-region/hub-and-spoke-vnet.tfvars
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+$tfvarsPath = Join-Path $PSScriptRoot 'test.auto.tfvars'
+$randomness = '{0:x4}' -f (Get-Random -Minimum 0 -Maximum 0x10000)
+
+$content = [System.IO.File]::ReadAllText($tfvarsPath)
+[System.IO.File]::WriteAllText($tfvarsPath, $content.Replace('rg-', "rg-$randomness-"))
+
+Write-Host "Added randomness '$randomness' to the resource group names."

--- a/examples/full-multi-region/pre.sh
+++ b/examples/full-multi-region/pre.sh
@@ -1,7 +1,0 @@
-echo "Downloading and creating the test.auto.tfvars file from https://raw.githubusercontent.com/Azure/alz-terraform-accelerator/refs/heads/main/templates/platform_landing_zone/examples/full-multi-region/hub-and-spoke-vnet.tfvars..."
-#curl -o test.auto.tfvars https://raw.githubusercontent.com/Azure/alz-terraform-accelerator/refs/heads/main/templates/platform_landing_zone/examples/full-multi-region/hub-and-spoke-vnet.tfvars
-echo "File downloaded successfully."
-echo "Adding randomness to the resource group names..."
-randomness=$(echo $RANDOM | md5sum | head -c 4)
-sed -i "s/rg-/rg-$randomness-/g" test.auto.tfvars
-echo "Randomness added to the resource group names."


### PR DESCRIPTION
Converts the lifecycle shell hook in `examples/full-multi-region` to PowerShell.

## Why the `.sh` file is deleted rather than kept alongside

The AVM authoring tooling rejects a lifecycle `.sh` hook on **presence alone** - a `.ps1`
sibling does not excuse it. The check is a pre-flight that throws before any tool runs, and it
exists in all four engines:

| Engine | Hooks scanned | Scope |
|---|---|---|
| `Invoke-AvmTerraformCheckPolicy.ps1:88-100` | `pre`, `post` | each active example |
| `Invoke-AvmTerraformTestE2e.ps1:167-179` | `pre`, `post` | each example dir |
| `Invoke-AvmTerraformTestSuite.ps1:111-125` | `setup`, `teardown` | `tests/<tier>/` |
| `Invoke-AvmTerraformLint.ps1:~250` | `tflint-pre` | each lint scope |

Adding the `.ps1` without removing the `.sh` would therefore still fail. The two must land
together, which is why this PR does both.

## Faithfulness notes

- `'{0:x4}' -f (Get-Random -Minimum 0 -Maximum 0x10000)` reproduces the shape of the original
  `md5sum | head -c 4` - four lowercase hex characters.
- Uses `.Replace()` (literal), not `-replace` (regex), matching `sed s/rg-/.../g`.
- `[System.IO.File]::ReadAllText`/`WriteAllText` preserves the tracked file's existing line
  endings, which `Get-Content`/`Set-Content` would rewrite.

## Two echo lines dropped deliberately

The original prints "Downloading and creating the test.auto.tfvars file from &lt;url&gt;..." and
"File downloaded successfully.", but the `curl` that would perform that download **is commented
out** - nothing was ever downloaded. A line-by-line port would carry those false messages
forward, so they are removed. The source URL is kept as a one-line comment for provenance.

## Validation

`test.auto.tfvars` is tracked and does contain `rg-` occurrences, so the replacement is
non-vacuous. After the hook runs: every `rg-` occurrence is rewritten, exactly one randomness
token is used throughout, no bare `rg-` remains, the line-ending histogram is unchanged, and the
byte delta is exactly 5 x the occurrence count. The file parses cleanly.